### PR TITLE
add 'images' task, fix issue #11

### DIFF
--- a/src/integrationTest/groovy/de/gesellix/gradle/docker/DockerPluginIntegrationTest.groovy
+++ b/src/integrationTest/groovy/de/gesellix/gradle/docker/DockerPluginIntegrationTest.groovy
@@ -149,6 +149,20 @@ class DockerPluginIntegrationTest extends Specification {
     }.size() == 1
   }
 
+  def "test images"() {
+    given:
+    def task = project.task('testImages', type: DockerImagesTask)
+    task.dockerHost = DOCKER_HOST
+
+    when:
+    def imagesResult = task.images()
+
+    then:
+    imagesResult.findAll {
+      it.RepoTags.contains "buildTest:latest"
+    }.size() == 1
+  }
+
   @Ignore("not yet implemented")
   def "test deploy"() {
     given:

--- a/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerImagesTask.groovy
+++ b/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerImagesTask.groovy
@@ -1,0 +1,22 @@
+package de.gesellix.gradle.docker.tasks
+
+import org.gradle.api.tasks.TaskAction
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class DockerImagesTask extends AbstractDockerTask {
+
+  private static Logger logger = LoggerFactory.getLogger(DockerPsTask)
+
+  def images
+
+  DockerImagesTask() {
+    description = "lists all images"
+  }
+
+  @TaskAction
+  def images() {
+    logger.info "running ps..."
+    images = getDockerClient().images()
+  }
+}

--- a/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerImagesTaskSpec.groovy
+++ b/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerImagesTaskSpec.groovy
@@ -1,0 +1,29 @@
+package de.gesellix.gradle.docker.tasks
+
+import de.gesellix.docker.client.DockerClient
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class DockerImagesTaskSpec extends Specification {
+
+  def project
+  def task
+  def dockerClient = Mock(DockerClient)
+
+  def setup() {
+    project = ProjectBuilder.builder().build()
+    task = project.task('dockerImages', type: DockerImagesTask)
+    task.dockerClient = dockerClient
+  }
+
+  def "delegates to dockerClient and saves result"() {
+    when:
+    task.images()
+
+    then:
+    1 * dockerClient.images() >> ["image"]
+
+    and:
+    task.images == ["image"]
+  }
+}


### PR DESCRIPTION
Hi,

This is a proposal for listing images using the Gradle plugin. Currently, I have a specific task in my `build.gradle`s. It would be great if this action could be available directly in the plugin.

Thanks for your work!
