### PR TITLE
A safer way of handling default values form extension in tasks

### DIFF
--- a/src/main/groovy/de/gesellix/gradle/docker/DockerPlugin.groovy
+++ b/src/main/groovy/de/gesellix/gradle/docker/DockerPlugin.groovy
@@ -10,7 +10,7 @@ public class DockerPlugin implements Plugin<Project> {
 
     def Logger logger = LoggerFactory.getLogger(DockerPlugin)
 
-    final def EXTENSION_NAME = 'docker'
+    static final String EXTENSION_NAME = 'docker'
 
     @Override
     void apply(Project project) {
@@ -18,14 +18,5 @@ public class DockerPlugin implements Plugin<Project> {
 
         logger.debug "ensure '${EXTENSION_NAME}' extension exists"
         def extension = project.extensions.findByName(EXTENSION_NAME) ?: project.extensions.create(EXTENSION_NAME, DockerPluginExtension, project)
-
-        project.tasks.withType(DockerTask) { task ->
-            logger.debug "apply '${EXTENSION_NAME}' extension config to $task"
-            task.dockerHost = extension.dockerHost
-            task.certPath = extension.getCertPath()
-            task.proxy = extension.proxy
-            task.authConfigPlain = extension.authConfigPlain
-            task.authConfigEncoded = extension.authConfigEncoded
-        }
     }
 }

--- a/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerTask.groovy
+++ b/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerTask.groovy
@@ -3,27 +3,114 @@ package de.gesellix.gradle.docker.tasks
 import de.gesellix.docker.client.DockerClient
 import de.gesellix.docker.client.DockerClientImpl
 import de.gesellix.docker.client.DockerConfig
+import de.gesellix.gradle.docker.DockerPlugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import org.gradle.util.CollectionUtils
 
+/** The base class for all Docker-related tasks.
+ */
 class DockerTask extends DefaultTask {
 
+    /** Sets a Docker host other than the one in the {@code docker} project extension
+     *
+     * @param host Any object can be converted to a string, including a closure that will resolve to a string.
+     */
+    void setDockerHost(def host) {
+        this.dockerHost = host
+    }
+
+    /** Obtains the docker host for the task instance. If a host was not set, the one that has been set in the
+     * {@code docker} project extension will be returned.
+     * @return A string containing the URL of the Docker host. (Could return null if not project extension is defined).
+     */
     @Input
     @Optional
-    def dockerHost
+    String getDockerHost() {
+        def host = dockerHost ?: project.extensions.findByName(DockerPlugin.EXTENSION_NAME)?.dockerHost
+        host ? CollectionUtils.stringize([host])[0] : null
+    }
+
+    /** Sets a certificate path other than the one in the {@code docker} project extension.
+     *
+     * @param certPath Any object can be converted to a string, including a closure that will resolve to a string.
+     */
+    void setCertPath(def certPath) {
+        this.certPath = certPath
+    }
+
+    /** Obtains the certificate path for the task instance. If a certificate path was not set, the one that has been set
+     * in the {@code docker} project extension will be returned.
+     * @return The certificate path as an absolute path string. (Could return null if not project extension is defined).
+     */
     @Input
     @Optional
-    def certPath
+    String getCertPath() {
+        this.certPath ? project.file(this.certPath).absolutePath : project.extensions.findByName(DockerPlugin.EXTENSION_NAME)?.certPath
+    }
+
+    /** Sets a proxy other than the one in the {@code docker} project extension.
+     *
+     * @param proxy A proxy object as understood by {@link de.gesellix.docker.client.DockerClientImpl}
+     */
+    void setProxy(def proxy) {
+        this.proxy = proxy
+    }
+
+    /** Obtains the proxy to be used for this task. If the proxy was not set, the default from {@code docker}
+     * project extension is returned.
+     *
+     * @return The proxy object or null if proxy has not been set in project extension (or if project extension is not
+     * defined).
+     */
     @Input
     @Optional
-    def proxy
+    def getProxy() {
+        this.proxy ?: project.extensions.findByName(DockerPlugin.EXTENSION_NAME)?.proxy
+    }
+
+    /** Sets a configuration string which will require encoding.
+     * {@link #setAuthConfigPlain} and {@link #setAuthConfigEncoded} are mutually exclusive. Both cannot be set on the
+     * same task.
+     *
+     * @param authConfigPlain
+     */
+    void setAuthConfigPlain(def authConfigPlain) {
+        this.authConfigPlain = authConfigPlain
+    }
+
+    /** Obtains a configuration string that requires encoding. If this is not set, the default from {@code docker}
+     * extension will be returned.
+     *
+     * @return Authentication in plain text
+     */
     @Input
     @Optional
-    def authConfigPlain
+    def getAuthConfigPlain() {
+        this.authConfigPlain ?: project.extensions.findByName(DockerPlugin.EXTENSION_NAME)?.authConfigPlain
+    }
+
+    /** Sets a configuration string which ire already encoded.
+     * {@link #setAuthConfigPlain} and {@link #setAuthConfigEncoded} are mutually exclusive. Both cannot be set on the
+     * same task.
+     *
+     * @param authConfigEncoded
+     */
+    void setAuthConfigEncoded(def authConfigEncoded) {
+        this.authConfigEncoded = authConfigEncoded
+    }
+
+    /** Obtains a configuration string that is already encoded. If this is not set, the default from {@code docker}
+     * extension will be returned.
+     *
+     * @return Encoded authentication string
+     */
     @Input
     @Optional
-    def authConfigEncoded
+    def getAuthConfigEncoded() {
+        this.authConfigEncoded ?: project.extensions.findByName(DockerPlugin.EXTENSION_NAME)?.authConfigEncoded
+    }
 
     DockerClient dockerClient
 
@@ -47,14 +134,35 @@ class DockerTask extends DefaultTask {
         dockerClient
     }
 
+    /** Returns an object that is suitable for authentication or an empty string if no authenticaiton was set up.
+     *
+     * @return Authentication object
+     */
     def getAuthConfig() {
-        if (getAuthConfigPlain()) {
-            assert !getAuthConfigEncoded()
+        // NOTE: To keep behaviour from previous versions we need to access the fields directly.
+        //       Once we know the field is set we can proceed as per normal as we'll obtain the
+        //       same result. In the older versions values were pushed down to task instances from
+        //       the settings in the extension. In order to be sure than we obtain the defaults
+        //       from the extension we need to call the getters, which will return the extension values
+        if (this.authConfigPlain) {
+            assert !this.authConfigEncoded
+            return getDockerClient().encodeAuthConfig(this.authConfigPlain)
+        }
+        if (this.authConfigEncoded) {
+            return authConfigEncoded
+        }
+        if(getAuthConfigPlain()) {
             return getDockerClient().encodeAuthConfig(getAuthConfigPlain())
         }
-        if (getAuthConfigEncoded()) {
-            return getAuthConfigEncoded()
-        }
-        ''
+
+        return getAuthConfigEncoded() ?: ''
     }
+
+    private Object dockerHost
+    private Object certPath
+    private Object proxy
+    private Object authConfigPlain
+    private Object authConfigEncoded
+
+
 }


### PR DESCRIPTION
@gesellix You might choose or not choose to use htis, but it shows an alternative way of handlng default values within anything that derives from `DockerTask`. 

* This removes the need for using `withType` (or `whenTaskAdded`) by handling everything inside `DockerTask`.
* Returned result from `getAuthConfig` remains the same as far as I could tell - no unit tests needed to be fixed, so I assume my refactoing works correctly
* I have dropped the properties in to private fields and used getter to retrieve either a locally set value or hte one form the extension.
* I have allowed for lazy evaluation for the `certPath` & `dockerHost` attributes.
* There are also some comments in `getAuthConfig` to try to explain why the code looks like it repeats itself.

P.S. I have taken the liberty of adding docs for the methods.