### PR TITLE
Add possibility to remove volumes in DockerDisposeContainerTask

### DIFF
--- a/plugin/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTask.groovy
+++ b/plugin/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTask.groovy
@@ -12,6 +12,9 @@ class DockerDisposeContainerTask extends GenericDockerTask {
     @Input
     @Optional
     def rmiParentImage = false
+    @Input
+    @Optional
+    boolean removeVolumes = false
 
     DockerDisposeContainerTask() {
         description = "Stops and removes a container and optionally its parent image"
@@ -38,7 +41,7 @@ class DockerDisposeContainerTask extends GenericDockerTask {
         }
         getDockerClient().stop(containerId)
         getDockerClient().wait(containerId)
-        getDockerClient().rm(containerId)
+        getDockerClient().rm(containerId, ["v": getRemoveVolumes() ? 1 : 0])
         if (getRmiParentImage()) {
             getDockerClient().rmi(containerDetails.content.Image)
         }

--- a/plugin/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
+++ b/plugin/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
@@ -29,7 +29,7 @@ class DockerDisposeContainerTaskSpec extends Specification {
         then:
         1 * dockerClient.wait("4712")
         then:
-        1 * dockerClient.rm("4712")
+        1 * dockerClient.rm("4712", [v: 0])
         and:
         0 * dockerClient.rmi(_)
     }
@@ -48,7 +48,7 @@ class DockerDisposeContainerTaskSpec extends Specification {
         then:
         1 * dockerClient.wait("4712")
         then:
-        1 * dockerClient.rm("4712")
+        1 * dockerClient.rm("4712", [v: 0])
         then:
         1 * dockerClient.rmi("an-image-id")
     }

--- a/plugin/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
+++ b/plugin/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
@@ -79,4 +79,16 @@ class DockerDisposeContainerTaskSpec extends Specification {
         then:
         1 * dockerClient.rm("4712", [v: 1])
     }
+
+    def "does not remove Volumes by default"() {
+        given:
+        task.containerId = "4712"
+
+        when:
+        task.dispose()
+
+        then:
+        task.removeVolumes == false
+        1 * dockerClient.rm("4712", [v: 0])
+    }
 }

--- a/plugin/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
+++ b/plugin/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
@@ -67,4 +67,16 @@ class DockerDisposeContainerTaskSpec extends Specification {
         then:
         0 * dockerClient._
     }
+
+    def "allows to removeVolumes"() {
+        given:
+        task.containerId = "4712"
+        task.removeVolumes = true
+
+        when:
+        task.dispose()
+
+        then:
+        1 * dockerClient.rm("4712", [v: 1])
+    }
 }


### PR DESCRIPTION
Similar to the DockerRmTask I would like the DockerDisposeContainerTask to have a possibility to remove volumes along with it.