### PR TITLE
Remove tags from the pluginBundle

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -120,7 +120,7 @@ pluginBundle {
   website = "https://github.com/gesellix/gradle-docker-plugin"
   vcsUrl = "https://github.com/gesellix/gradle-docker-plugin.git"
   description = "A Docker plugin for Gradle"
-  tags = listOf("docker", "gradle", "remote api", "plugin")
+  tags = listOf("docker", "remote api", "client")
 
   plugins {
     register(publicationName) {


### PR DESCRIPTION
Seems like some tags are deprecated now:

```
Task ':plugin:publishPlugins' is not up-to-date because:
> Failed to post to server.
  Task has not declared any outputs despite executing actions.
  Server responded with:
Could not reuse POM from pluginMaven publication because mavenCoordinates() was used
  Some tag provided are forbidden: gradle,pluging
Publishing plugin de.gesellix.docker version 2021-12-18T23-57-00
```